### PR TITLE
PyGeneratorExp, better comprehension output

### DIFF
--- a/clara/feedback_python.py
+++ b/clara/feedback_python.py
@@ -241,6 +241,8 @@ class PythonStatementGenerator(object):
                 ret = PySetComp(args[1], [PyComprehension([PyVariable(self.getBoundVarName(x)) for x in range(int(str(args[0])))], args[-2], [args[-1]])])
             elif expr.name == 'DictComp':
                 ret = PyDictComp(args[1], args[2], [PyComprehension([PyVariable(self.getBoundVarName(x)) for x in range(int(str(args[0])))], args[-2], [args[-1]])])
+            elif expr.name == 'GeneratorExp':
+                ret = PyGeneratorExp(args[1], [PyComprehension([PyVariable(self.getBoundVarName(x)) for x in range(int(str(args[0])))], args[-2], [args[-1]])])
             elif expr.name == 'BoundVar':
                 ret = PyVariable(self.getBoundVarName(int(expr.args[0].value)))
             elif expr.args != None:
@@ -348,6 +350,7 @@ class PyAssignment(PyExpression):
     def __init__(self, variable, assigned):
         if not variable.isLValue():
             raise NotAnLValueException(variable)
+            pass
         self.variable = variable
         self.assigned = assigned
         
@@ -543,3 +546,10 @@ class PyDictComp(PyExpression):
     def __repr__(self):
         return '{%s: %s %s}' % (self.key, self.value, (' ').join([str(gen) for gen in self.generators]) )
     
+class PyGeneratorExp(PyExpression):
+    def __init__(self, elt, generators):
+        self.elt = elt
+        self.generators = generators
+        
+    def __repr__(self):
+        return '%s %s' % (self.elt , ' '.join([str(gen) for gen in self.generators]))

--- a/clara/feedback_python.py
+++ b/clara/feedback_python.py
@@ -519,7 +519,10 @@ class PyComprehension(PyExpression):
         self.ifs = ifs
         
     def __repr__(self):
-        return 'for %s in %s if %s' % (', '.join([str(var) for var in self.target]), str(self.iter), ' if '.join([str(cond) for cond in self.ifs]))
+        ret = 'for %s in %s' % (', '.join([str(var) for var in self.target]), str(self.iter))
+        if len(self.ifs) != 1 or str(self.ifs[0]) != 'True':
+            ret = ret + ' if ' + 'if '.join([str(cond) for cond in self.ifs])
+        return ret
     
 class PyListComp(PyExpression):
     def __init__(self, elt, generators):


### PR DESCRIPTION
Hi, I've fixed the problem with GeneratorExp – I wasn't aware that that existed. I also made the comprehension output omit "if True".

But I have no idea how to even approach this one (which I suspect is very similar to the other problems): https://clara.forsyte.tuwien.ac.at/results?code_id=9000006014782

  result := ite(Eq(GetElement(inPoly, i), 0.0), result, ite(Eq(i, 0), AssignElement(append(result, Mult(GetElement(inPoly, i), i)), 0, 0.0), append(result, Mult(GetElement(inPoly, i), i))))

This is merging too much for my code to handle – the exception gets thrown at "AssignElement(append(result, Mult,...whatever", where the left side of AssignElement isn't something that can be assigned to. If I just remove the code that raises the exception, I get this:

* * Change 'result = (result if (inPoly[i] == 0.0) else (result.append((inPoly[i] * i))[0] = 0.0 if (i == 0) else result.append((inPoly[i] * i))))' to 'result = result.append((poly[i] * float(i)))' inside the body of the 'while' loop beginning at line 30 (cost=23)

But "result.append((inPoly[i] * i))[0] = 0.0" is also not what I want. In fact I'm not sure exactly *what* I want there. The merging of that if-then-else statement combined with an "append" operation being treated like an assignment isn't close enough to anything valid in Python that I know what to do. Any advice?

Paul