### PR TITLE
Fix (name) constants accross various supported 3.x Python versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TODO: Test on version 3.8
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ programming assignments, described in the following paper:
 (https://dl.acm.org/doi/10.1145/3192366.3192387 and https://arxiv.org/abs/1603.03165).
 
 
+Supported Python versions
+=========================
+
+The package is currently tested on the following Python versions:
+- 3.6
+- 3.7
+- 3.8
+- 3.9
+
 Dependencies
 ============
 - C compiler
@@ -94,7 +103,3 @@ Note
 ----
 
 You can add `--verbose 1` to any of the examples to obtain a more verbose output.
-
-Known issues
-------------
-May not work well on Python 3.8.

--- a/clara/py_parser.py
+++ b/clara/py_parser.py
@@ -79,7 +79,7 @@ class PyParser(Parser):
             return self.visit(node, "Str")
         elif isinstance(node.value, bytes):
             return self.visit(node, "Bytes")
-        elif isinstance(node.value, bool):
+        elif node.value is None or isinstance(node.value, bool):
             return self.visit(node, "NameConstant")
         elif node.value is Ellipsis:
             return self.visit(node, "Ellipsis")
@@ -87,6 +87,9 @@ class PyParser(Parser):
             return self.visit(node, "Num")
         else:
             raise NotSupported("Unimplemented Constant visitor for '%s'" % (node.value,))
+
+    def visit_NameConstant(self, node):
+        return Const(str(node.value))
 
     def visit_Num(self, node):
         if type(node.n) in (int, float, int, complex):

--- a/tests/data/named_consts.py
+++ b/tests/data/named_consts.py
@@ -1,0 +1,7 @@
+def main(name):
+    if name is None:
+        return None
+    elif not name:
+        return False
+    else:
+        return True

--- a/tests/data/named_consts.py
+++ b/tests/data/named_consts.py
@@ -1,7 +1,8 @@
-def main(name):
-    if name is None:
-        return None
-    elif not name:
-        return False
-    else:
-        return True
+def main():
+    # Test all the different constants
+    v1 = "Hello world"
+    v2 = 42
+    v3 = 42.333
+    v4 = True
+    v5 = False
+    v6 = None

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -5,7 +5,7 @@ Some basic (regression) Python tests
 from utils import get_full_data_filename, parse_file
 
 from clara.interpreter import getlanginter
-from clara.model import VAR_RET, prime
+from clara.model import VAR_RET, prime, Const
 from clara.parser import getlangparser
 
 def test_list_comp():
@@ -30,8 +30,27 @@ def test_list_comp():
         value = trace[-1][2][retvar]
         assert value == o
 
-def test_named_consts():
+def test_consts():
     f = get_full_data_filename("named_consts.py")
     parser = getlangparser("py")
     m = parse_file(f, parser)
-    assert m is not None
+    main = m.getfnc("main")
+    loc = list(main.locs())[0]
+
+    def check_expr(e, v):
+        assert isinstance(e, Const)
+        assert e.value == v
+
+    consts = [
+        ("v1", "\"Hello world\""),
+        ("v2", "42"),
+        ("v3", "42.333"),
+        ("v4", "True"),
+        ("v5", "False"),
+        ("v6", "None")
+    ]
+
+    for var, val in consts:
+        check_expr(main.getexpr(loc, var), val)
+
+

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -5,7 +5,6 @@ Some basic (regression) Python tests
 from utils import get_full_data_filename, parse_file
 
 from clara.interpreter import getlanginter
-from clara.matching import Matching
 from clara.model import VAR_RET, prime
 from clara.parser import getlangparser
 
@@ -30,3 +29,9 @@ def test_list_comp():
         print(trace)
         value = trace[-1][2][retvar]
         assert value == o
+
+def test_named_consts():
+    f = get_full_data_filename("named_consts.py")
+    parser = getlangparser("py")
+    m = parse_file(f, parser)
+    assert m is not None

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,8 +2,6 @@
 Some basic (regression) Python tests
 """
 
-import pytest
-
 from utils import get_full_data_filename, parse_file
 
 from clara.interpreter import getlanginter


### PR DESCRIPTION
Fixes handling of various constants in Python 3.x.